### PR TITLE
Refactor website

### DIFF
--- a/src/components/PrizePool.jsx
+++ b/src/components/PrizePool.jsx
@@ -15,7 +15,7 @@ const PrizeCard = ({ prize }) => {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.6, delay: prize.delay }}
-      className={`relative w-full max-w-[320px] h-[420px] flex flex-col ${prize.mobileOrder} ${prize.desktopOrder} ${prize.transform} cursor-pointer [perspective:1000px] group`}
+      className={`relative w-full max-w-[280px] sm:max-w-[320px] h-[360px] sm:h-[400px] md:h-[420px] flex flex-col ${prize.mobileOrder} ${prize.desktopOrder} ${prize.transform} cursor-pointer [perspective:1000px] group`}
       onClick={() => setIsFlipped(!isFlipped)}
     >
       <motion.div
@@ -159,7 +159,7 @@ const PrizePool = () => {
   ];
 
   return (
-    <section ref={sectionRef} className="py-32 px-6 relative bg-transparent overflow-hidden">
+    <section ref={sectionRef} className="py-16 sm:py-24 md:py-32 px-4 sm:px-6 relative bg-transparent overflow-hidden">
       <div className="container mx-auto max-w-6xl relative z-10">
         
         {/* Header Section */}
@@ -169,7 +169,7 @@ const PrizePool = () => {
           viewport={{ once: true }} 
           className="text-center mb-20"
         >
-          <h2 className="text-4xl md:text-7xl font-black text-white mb-4 tracking-tighter">
+          <h2 className="text-3xl sm:text-4xl md:text-7xl font-black text-white mb-4 tracking-tighter">
             Prize <span className="text-purple-500">Pool</span>
           </h2>
           <div className="h-[2px] w-24 bg-gradient-to-r from-transparent via-purple-500 to-transparent mx-auto mt-6" />
@@ -180,7 +180,7 @@ const PrizePool = () => {
           initial={{ opacity: 0, scale: 0.95 }}
           whileInView={{ opacity: 1, scale: 1 }}
           viewport={{ once: true }}
-          className="relative mx-auto max-w-4xl mb-32 p-12 overflow-hidden rounded-[3rem] border border-white/5 bg-[#050505]/60 shadow-[0_0_80px_-20px_rgba(168,85,247,0.15)] backdrop-blur-md"
+          className="relative mx-auto max-w-4xl mb-16 sm:mb-24 md:mb-32 p-6 sm:p-8 md:p-12 overflow-hidden rounded-[2rem] sm:rounded-[3rem] border border-white/5 bg-[#050505]/60 shadow-[0_0_80px_-20px_rgba(168,85,247,0.15)] backdrop-blur-md"
         >
           {/* Side Glow Lights */}
           <div className="absolute -top-12 -left-12 w-72 h-72 bg-purple-600 rounded-full blur-[110px] opacity-20 pointer-events-none"></div>
@@ -199,12 +199,12 @@ const PrizePool = () => {
             
             <div className="relative">
               <div className="absolute inset-0 blur-3xl bg-purple-600/30 rounded-full scale-150 opacity-60"></div>
-              <h3 className="relative text-7xl md:text-9xl lg:text-[10rem] font-black tracking-tighter leading-none text-white drop-shadow-[0_0_20px_rgba(255,255,255,0.3)]">
+              <h3 className="relative text-4xl sm:text-6xl md:text-9xl lg:text-[10rem] font-black tracking-tighter leading-none text-white drop-shadow-[0_0_20px_rgba(255,255,255,0.3)]">
                 {totalPrize}
               </h3>
             </div>
 
-            <div className="mt-12 flex gap-8 text-[10px] font-mono text-zinc-500 uppercase tracking-widest">
+            <div className="mt-8 sm:mt-12 flex flex-wrap justify-center gap-4 sm:gap-8 text-[8px] sm:text-[10px] font-mono text-zinc-500 uppercase tracking-widest">
                 <span className="flex items-center gap-2"><div className="w-1 h-1 rounded-full bg-cyan-400"></div> Sector :: 0x-Event</span>
                 <div className="w-[1px] h-3 bg-white/10"></div>
                 <span className="text-zinc-400">Protocol :: Encode V.2026</span>

--- a/src/components/aboutCA.jsx
+++ b/src/components/aboutCA.jsx
@@ -124,7 +124,7 @@ function FeatureCard({ icon, title, desc, floatClass }) {
         {icon}
       </div>
       <h3 className="text-white font-semibold mb-1 md:mb-2">{title}</h3>
-      <p className="hidden md:block text-sm text-zinc-400 leading-relaxed">{desc}</p>
+      <p className="text-xs md:text-sm text-zinc-400 leading-relaxed">{desc}</p>
     </div>
   );
 }

--- a/src/components/events1.jsx
+++ b/src/components/events1.jsx
@@ -1,28 +1,45 @@
 "use client";
 
-import React, { useRef, useState } from 'react';
-import { motion } from 'framer-motion';
-import { Terminal, Zap, Layers, ChevronRight, Sparkles, RotateCcw } from 'lucide-react';
+import React, { useRef, useState, useCallback, useEffect } from "react";
+import { motion } from "framer-motion";
+import {
+  Terminal,
+  Zap,
+  Layers,
+  ChevronRight,
+  ChevronLeft,
+  Sparkles,
+  RotateCcw,
+} from "lucide-react";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+} from "./ui/carousel";
 
 // --- Individual Event Card Component ---
-const EventCard = ({ title, description, link, icon: Icon, delay, platform, date, format }) => {
+const EventCard = ({
+  title,
+  description,
+  link,
+  icon: Icon,
+  platform,
+  date,
+  format,
+  accentColor,
+  accentGlow,
+}) => {
   const [isFlipped, setIsFlipped] = useState(false);
   const isFeatured = title === "CodeArena";
 
-  const handleCardClick = (e) => {
-    if (e.target.closest('[data-mission-link]')) return;
-    e.preventDefault();
+  const handleFlip = (e) => {
+    e.stopPropagation();
     setIsFlipped(!isFlipped);
   };
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 20 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true }}
-      transition={{ duration: 0.5, delay }}
-      className={`block w-full ${isFeatured ? 'md:w-[42%] h-[380px] sm:h-[420px] md:h-[55vh] z-20' : 'md:w-[29%] h-[340px] sm:h-[380px] md:h-[45vh] z-10'} [perspective:1200px] cursor-pointer`}
-      onClick={handleCardClick}
+    <div
+      className="w-full h-[380px] sm:h-[420px] [perspective:1200px]"
     >
       <motion.div
         className="relative w-full h-full [transform-style:preserve-3d]"
@@ -30,102 +47,184 @@ const EventCard = ({ title, description, link, icon: Icon, delay, platform, date
         transition={{ duration: 0.8, type: "spring", bounce: 0.2 }}
       >
         {/* --- FRONT SIDE --- */}
-        <div className={`absolute inset-0 flex flex-col items-center justify-center rounded-[2rem] sm:rounded-[3rem] border-2 backdrop-blur-2xl p-6 sm:p-8 [backface-visibility:hidden] shadow-2xl overflow-hidden
-          ${isFeatured ? 'border-purple-500/50 bg-purple-950/20 shadow-purple-500/20' : 'border-white/10 bg-[#0a0a0a]/40 shadow-black'}`}>
+        <div
+          className={`absolute inset-0 flex flex-col items-center justify-center rounded-[2rem] border-2 backdrop-blur-2xl p-6 sm:p-8 [backface-visibility:hidden] shadow-2xl overflow-hidden
+          ${isFeatured ? "border-purple-500/50 bg-purple-950/20 shadow-purple-500/20" : "border-white/10 bg-[#0a0a0a]/40 shadow-black"}`}
+        >
+          {/* Grid pattern */}
+          <div
+            className="absolute inset-0 opacity-10"
+            style={{
+              backgroundImage:
+                "linear-gradient(to right, #ffffff10 1px, transparent 1px), linear-gradient(to bottom, #ffffff10 1px, transparent 1px)",
+              backgroundSize: "30px 30px",
+            }}
+          />
 
-          <div className="absolute inset-0 opacity-10" style={{ backgroundImage: 'linear-gradient(to right, #ffffff10 1px, transparent 1px), linear-gradient(to bottom, #ffffff10 1px, transparent 1px)', backgroundSize: '30px 30px' }}></div>
-
+          {/* Scanning laser — CodeArena only */}
           {isFeatured && (
             <motion.div
-              animate={{ top: ['-10%', '110%'] }}
+              animate={{ top: ["-10%", "110%"] }}
               transition={{ duration: 4, repeat: Infinity, ease: "linear" }}
               className="absolute inset-x-0 h-[2px] bg-gradient-to-r from-transparent via-purple-400 to-transparent z-0 opacity-50 shadow-[0_0_15px_purple]"
             />
           )}
 
-          <div className={`absolute -top-20 -right-20 w-48 h-48 rounded-full blur-[80px] opacity-20 pointer-events-none 
-            ${isFeatured ? 'bg-purple-600' : 'bg-blue-600'}`}></div>
+          {/* Nebula glow */}
+          <div
+            className={`absolute -top-20 -right-20 w-48 h-48 rounded-full blur-[80px] opacity-20 pointer-events-none ${accentGlow}`}
+          />
 
           <div className="relative z-10 flex flex-col items-center">
-            <div className="relative mb-6 sm:mb-8">
+            {/* Icon with orbital ring */}
+            <div className="relative mb-6">
               <motion.div
                 animate={{ rotate: 360 }}
                 transition={{ duration: 15, repeat: Infinity, ease: "linear" }}
-                className={`absolute -inset-4 border-2 border-dashed rounded-full opacity-30 ${isFeatured ? 'border-purple-400' : 'border-white/20'}`}
+                className={`absolute -inset-4 border-2 border-dashed rounded-full opacity-30 ${isFeatured ? "border-purple-400" : "border-white/20"}`}
               />
-              <div className={`relative p-4 sm:p-6 rounded-full border shadow-2xl transition-transform duration-500 
-                  ${isFeatured ? 'bg-purple-500/10 border-purple-500/30' : 'bg-white/5 border-white/10'}`}>
-                <Icon size={isFeatured ? 44 : 32} strokeWidth={1} className={isFeatured ? "text-purple-400 drop-shadow-[0_0_8px_#a855f7]" : "text-white"} />
+              <div
+                className={`relative p-5 rounded-full border shadow-2xl
+                ${isFeatured ? "bg-purple-500/10 border-purple-500/30" : "bg-white/5 border-white/10"}`}
+              >
+                <Icon
+                  size={36}
+                  strokeWidth={1}
+                  className={accentColor}
+                />
               </div>
             </div>
 
-            <h3 className={`${isFeatured ? 'text-3xl sm:text-4xl' : 'text-xl sm:text-2xl'} font-black text-white uppercase tracking-tighter text-center leading-none`}>
+            <h3 className="text-2xl sm:text-3xl font-black text-white uppercase tracking-tighter text-center leading-none">
               {title}
             </h3>
 
-            <div className={`h-[2px] w-12 my-4 sm:my-5 rounded-full ${isFeatured ? 'bg-purple-500 shadow-[0_0_15px_#a855f7]' : 'bg-gradient-to-r from-transparent via-purple-500/50 to-transparent'}`}></div>
+            <div
+              className={`h-[2px] w-12 my-4 rounded-full ${isFeatured ? "bg-purple-500 shadow-[0_0_15px_#a855f7]" : "bg-gradient-to-r from-transparent via-purple-500/50 to-transparent"}`}
+            />
 
-            <span className={`text-[10px] font-black uppercase tracking-[0.4em] flex items-center gap-2 ${isFeatured ? 'text-purple-300' : 'text-zinc-500'}`}>
-              <Sparkles size={10} /> {isFeatured ? 'Main Mission' : 'Side Quest'}
+            <span
+              className={`text-[10px] font-black uppercase tracking-[0.4em] flex items-center gap-2 ${isFeatured ? "text-purple-300" : "text-zinc-500"}`}
+            >
+              <Sparkles size={10} />{" "}
+              {isFeatured ? "Main Mission" : "Side Quest"}
             </span>
 
-            <span className="mt-4 sm:mt-6 text-[9px] text-zinc-600 uppercase tracking-widest animate-pulse">
-              Tap to reveal
-            </span>
+            <button
+              onClick={handleFlip}
+              className={`mt-5 flex items-center gap-2 text-[10px] font-bold uppercase tracking-widest px-5 py-2 rounded-full border transition-all duration-300 hover:scale-105 active:scale-95 cursor-pointer
+              ${isFeatured ? "text-purple-300 border-purple-500/40 bg-purple-500/10 hover:bg-purple-500/20" : "text-zinc-400 border-white/10 bg-white/5 hover:bg-white/10"}`}
+            >
+              View Mission <ChevronRight size={12} />
+            </button>
           </div>
         </div>
 
         {/* --- BACK SIDE --- */}
-        <div className="absolute inset-0 flex flex-col items-center justify-center rounded-[2rem] sm:rounded-[3rem] bg-[#070707] border-2 border-white/20 p-6 sm:p-10 text-center [transform:rotateY(180deg)] [backface-visibility:hidden] shadow-2xl overflow-hidden">
-          <span className="text-[10px] font-black text-cyan-400 uppercase tracking-[0.4em] mb-3 sm:mb-4">
+        <div className="absolute inset-0 flex flex-col items-center justify-center rounded-[2rem] bg-[#070707] border-2 border-white/20 p-6 sm:p-8 text-center [transform:rotateY(180deg)] [backface-visibility:hidden] shadow-2xl overflow-hidden">
+          <span className="text-[10px] font-black text-cyan-400 uppercase tracking-[0.4em] mb-4">
             Mission Briefing
           </span>
 
-          <div className="space-y-2 mb-4 sm:mb-6 w-full max-w-[260px]">
-            <div className="flex justify-between text-[10px] sm:text-xs border-b border-white/5 pb-1">
-              <span className="text-zinc-500 font-bold uppercase tracking-wider">Platform</span>
-              <span className="text-white font-semibold">{platform}</span>
-            </div>
-            <div className="flex justify-between text-[10px] sm:text-xs border-b border-white/5 pb-1">
-              <span className="text-zinc-500 font-bold uppercase tracking-wider">Date</span>
-              <span className="text-white font-semibold">{date}</span>
-            </div>
-            <div className="flex justify-between text-[10px] sm:text-xs border-b border-white/5 pb-1">
-              <span className="text-zinc-500 font-bold uppercase tracking-wider">Format</span>
-              <span className="text-white font-semibold">{format}</span>
-            </div>
+          {/* Structured info */}
+          <div className="space-y-2 mb-5 w-full max-w-[260px]">
+            {[
+              { label: "Platform", value: platform },
+              { label: "Date", value: date },
+              { label: "Format", value: format },
+            ].map((row) => (
+              <div
+                key={row.label}
+                className="flex justify-between text-[10px] sm:text-xs border-b border-white/5 pb-1"
+              >
+                <span className="text-zinc-500 font-bold uppercase tracking-wider">
+                  {row.label}
+                </span>
+                <span className="text-white font-semibold">{row.value}</span>
+              </div>
+            ))}
           </div>
 
-          <p className={`${isFeatured ? 'text-sm sm:text-base' : 'text-xs sm:text-sm'} leading-relaxed text-zinc-400 font-light mb-4 sm:mb-6`}>
+          <p className="text-xs sm:text-sm leading-relaxed text-zinc-400 font-light mb-5">
             {description}
           </p>
 
           <a
             href={link}
             data-mission-link="true"
-            target={link.startsWith('http') ? '_blank' : '_self'}
-            rel={link.startsWith('http') ? 'noopener noreferrer' : undefined}
-            className={`flex items-center gap-2 text-[10px] sm:text-xs font-bold text-white uppercase tracking-widest px-6 sm:px-8 py-3 rounded-full border transition-all duration-300 hover:scale-105 active:scale-95
-            ${isFeatured ? 'bg-purple-600/20 border-purple-500 hover:bg-purple-500 hover:text-white' : 'bg-white/5 border-white/10 hover:bg-white hover:text-black'}`}
+            target={link.startsWith("http") ? "_blank" : "_self"}
+            rel={link.startsWith("http") ? "noopener noreferrer" : undefined}
+            className={`flex items-center gap-2 text-[10px] sm:text-xs font-bold text-white uppercase tracking-widest px-6 py-3 rounded-full border transition-all duration-300 hover:scale-105 active:scale-95
+            ${isFeatured ? "bg-purple-600/20 border-purple-500 hover:bg-purple-500" : "bg-white/5 border-white/10 hover:bg-white hover:text-black"}`}
           >
             Register Now <ChevronRight size={14} />
           </a>
 
           <button
-            className="mt-3 sm:mt-4 flex items-center gap-1.5 text-[9px] text-zinc-600 uppercase tracking-widest hover:text-zinc-400 transition-colors"
-            onClick={(e) => { e.stopPropagation(); setIsFlipped(false); }}
+            className="mt-3 flex items-center gap-1.5 text-[9px] text-zinc-600 uppercase tracking-widest hover:text-zinc-400 transition-colors cursor-pointer"
+            onClick={handleFlip}
           >
             <RotateCcw size={10} /> Tap to flip back
           </button>
         </div>
       </motion.div>
-    </motion.div>
+    </div>
   );
 };
+
+// --- Custom Navigation Arrows ---
+const NavButton = ({ direction, onClick, disabled }) => {
+  const ArrowIcon = direction === "prev" ? ChevronLeft : ChevronRight;
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full border-2 flex items-center justify-center transition-all duration-300
+        ${disabled
+          ? "border-white/5 text-zinc-700 cursor-not-allowed"
+          : "border-purple-500/40 text-purple-400 hover:bg-purple-500/20 hover:border-purple-500/60 hover:shadow-[0_0_20px_rgba(168,85,247,0.3)] active:scale-90"
+        }`}
+    >
+      <ArrowIcon size={20} />
+    </button>
+  );
+};
+
+// --- Dot Indicators ---
+const DotIndicators = ({ total, current }) => (
+  <div className="flex items-center gap-2">
+    {Array.from({ length: total }).map((_, i) => (
+      <div
+        key={i}
+        className={`rounded-full transition-all duration-500 ${
+          i === current
+            ? "w-6 h-2 bg-purple-500 shadow-[0_0_10px_rgba(168,85,247,0.5)]"
+            : "w-2 h-2 bg-white/10 hover:bg-white/20"
+        }`}
+      />
+    ))}
+  </div>
+);
 
 // --- Main Events Section ---
 const Events = () => {
   const sectionRef = useRef(null);
+  const [api, setApi] = useState(null);
+  const [current, setCurrent] = useState(0);
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!api) return;
+    setCount(api.scrollSnapList().length);
+    setCurrent(api.selectedScrollSnap());
+
+    const onSelect = () => setCurrent(api.selectedScrollSnap());
+    api.on("select", onSelect);
+    return () => api.off("select", onSelect);
+  }, [api]);
+
+  const scrollPrev = useCallback(() => api?.scrollPrev(), [api]);
+  const scrollNext = useCallback(() => api?.scrollNext(), [api]);
 
   const eventData = [
     {
@@ -134,9 +233,11 @@ const Events = () => {
       platform: "UpToSkills",
       date: "5 April",
       format: "DSA Quiz",
-      description: "Test your algorithmic speed and precision in a high-stakes competitive quiz gauntlet.",
+      accentColor: "text-cyan-400 drop-shadow-[0_0_8px_#22d3ee]",
+      accentGlow: "bg-cyan-600",
+      description:
+        "Test your algorithmic speed and precision in a high-stakes competitive quiz gauntlet.",
       link: "/codearena",
-      delay: 0.1
     },
     {
       title: "CodeArena",
@@ -144,9 +245,11 @@ const Events = () => {
       platform: "Codeforces",
       date: "5 April",
       format: "ICPC-Style CP",
-      description: "Solve the complex, optimize the simple, and dominate the live global leaderboard in a timed coding battle.",
+      accentColor: "text-purple-400 drop-shadow-[0_0_8px_#a855f7]",
+      accentGlow: "bg-purple-600",
+      description:
+        "Solve the complex, optimize the simple, and dominate the live global leaderboard in a timed coding battle.",
       link: "https://unstop.com/o/1cJ2LFR?utm_medium=Share&utm_source=online_coding_challenge&utm_campaign=Logged_out_userhttps://share.google/JZJwkBcHxZVeJOoh4",
-      delay: 0.2
     },
     {
       title: "Vibe Code Arena",
@@ -154,10 +257,12 @@ const Events = () => {
       platform: "HackerEarth",
       date: "25 Mar – 4 Apr",
       format: "AI Prompting",
-      description: "Leverage the power of LLMs to build at the speed of thought in this AI-powered coding competition.",
+      accentColor: "text-pink-400 drop-shadow-[0_0_8px_#f472b6]",
+      accentGlow: "bg-pink-600",
+      description:
+        "Leverage the power of LLMs to build at the speed of thought in this AI-powered coding competition.",
       link: "/codearena",
-      delay: 0.3
-    }
+    },
   ];
 
   return (
@@ -165,21 +270,24 @@ const Events = () => {
       ref={sectionRef}
       className="relative overflow-hidden bg-transparent px-4 sm:px-6 py-16 sm:py-24 md:py-32"
     >
-      <div className="absolute top-0 left-1/4 w-96 h-96 bg-purple-600/5 blur-[120px] pointer-events-none"></div>
-      <div className="absolute bottom-0 right-1/4 w-96 h-96 bg-cyan-600/5 blur-[120px] pointer-events-none"></div>
+      {/* Background ambience */}
+      <div className="absolute top-0 left-1/4 w-96 h-96 bg-purple-600/5 blur-[120px] pointer-events-none" />
+      <div className="absolute bottom-0 right-1/4 w-96 h-96 bg-cyan-600/5 blur-[120px] pointer-events-none" />
 
       <div className="container relative z-10 mx-auto max-w-7xl">
-
+        {/* Header */}
         <motion.div
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          className="relative mb-12 sm:mb-16 md:mb-24 text-center"
+          className="relative mb-12 sm:mb-16 md:mb-20 text-center"
         >
           <div className="flex items-center justify-center gap-4 mb-4">
-            <div className="h-[1px] w-12 bg-white/10"></div>
-            <span className="text-xs font-bold text-purple-400 uppercase tracking-[0.5em]">Sector :: Missions</span>
-            <div className="h-[1px] w-12 bg-white/10"></div>
+            <div className="h-[1px] w-12 bg-white/10" />
+            <span className="text-xs font-bold text-purple-400 uppercase tracking-[0.5em]">
+              Sector :: Missions
+            </span>
+            <div className="h-[1px] w-12 bg-white/10" />
           </div>
 
           <h2 className="text-3xl sm:text-5xl md:text-8xl font-black tracking-tighter text-white">
@@ -191,22 +299,50 @@ const Events = () => {
           </p>
         </motion.div>
 
-        <div className="flex flex-col md:flex-row justify-center items-center gap-6 sm:gap-8 lg:gap-10">
-          {eventData.map((event, idx) => (
-            <EventCard
-              key={idx}
-              title={event.title}
-              icon={event.icon}
-              description={event.description}
-              link={event.link}
-              platform={event.platform}
-              date={event.date}
-              format={event.format}
-              delay={event.delay}
-            />
-          ))}
-        </div>
+        {/* Carousel */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ delay: 0.2 }}
+        >
+          <Carousel
+            setApi={setApi}
+            opts={{
+              align: "center",
+              loop: true,
+            }}
+            className="w-full"
+          >
+            <CarouselContent className="-ml-4 sm:-ml-6">
+              {eventData.map((event, idx) => (
+                <CarouselItem
+                  key={idx}
+                  className="pl-4 sm:pl-6 basis-[85%] sm:basis-[70%] md:basis-1/3"
+                >
+                  <EventCard
+                    title={event.title}
+                    icon={event.icon}
+                    description={event.description}
+                    link={event.link}
+                    platform={event.platform}
+                    date={event.date}
+                    format={event.format}
+                    accentColor={event.accentColor}
+                    accentGlow={event.accentGlow}
+                  />
+                </CarouselItem>
+              ))}
+            </CarouselContent>
+          </Carousel>
 
+          {/* Custom Navigation Controls */}
+          <div className="flex items-center justify-center gap-6 mt-8 sm:mt-10">
+            <NavButton direction="prev" onClick={scrollPrev} disabled={!api} />
+            <DotIndicators total={count} current={current} />
+            <NavButton direction="next" onClick={scrollNext} disabled={!api} />
+          </div>
+        </motion.div>
       </div>
     </section>
   );

--- a/src/components/events1.jsx
+++ b/src/components/events1.jsx
@@ -1,89 +1,125 @@
 "use client";
 
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { motion } from 'framer-motion';
-import { Terminal, Zap, Layers, ChevronRight, Sparkles } from 'lucide-react';
+import { Terminal, Zap, Layers, ChevronRight, Sparkles, RotateCcw } from 'lucide-react';
 
 // --- Individual Event Card Component ---
-const EventCard = ({ title, description, link, icon: Icon, delay }) => {
-  // Logic to determine if this specific card should be bigger (CodeArena)
+const EventCard = ({ title, description, link, icon: Icon, delay, platform, date, format }) => {
+  const [isFlipped, setIsFlipped] = useState(false);
   const isFeatured = title === "CodeArena";
 
+  const handleCardClick = (e) => {
+    if (e.target.closest('[data-mission-link]')) return;
+    e.preventDefault();
+    setIsFlipped(!isFlipped);
+  };
+
   return (
-    <motion.a 
-      href={link}
+    <motion.div
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.5, delay }}
-      className={`block w-full ${isFeatured ? 'md:w-[42%] h-[55vh] z-20' : 'md:w-[29%] h-[45vh] z-10'} [perspective:1200px] group`}
+      className={`block w-full ${isFeatured ? 'md:w-[42%] h-[380px] sm:h-[420px] md:h-[55vh] z-20' : 'md:w-[29%] h-[340px] sm:h-[380px] md:h-[45vh] z-10'} [perspective:1200px] cursor-pointer`}
+      onClick={handleCardClick}
     >
       <motion.div
-        className="relative w-full h-full transition-all duration-1000 [transform-style:preserve-3d] group-hover:[transform:rotateY(180deg)]"
+        className="relative w-full h-full [transform-style:preserve-3d]"
+        animate={{ rotateY: isFlipped ? 180 : 0 }}
+        transition={{ duration: 0.8, type: "spring", bounce: 0.2 }}
       >
-        {/* --- FRONT SIDE (Space Glassmorphism) --- */}
-        <div className={`absolute inset-0 flex flex-col items-center justify-center rounded-[3rem] border-2 backdrop-blur-2xl p-8 [backface-visibility:hidden] shadow-2xl overflow-hidden
+        {/* --- FRONT SIDE --- */}
+        <div className={`absolute inset-0 flex flex-col items-center justify-center rounded-[2rem] sm:rounded-[3rem] border-2 backdrop-blur-2xl p-6 sm:p-8 [backface-visibility:hidden] shadow-2xl overflow-hidden
           ${isFeatured ? 'border-purple-500/50 bg-purple-950/20 shadow-purple-500/20' : 'border-white/10 bg-[#0a0a0a]/40 shadow-black'}`}>
-          
-          {/* Internal Grid/Space Background */}
+
           <div className="absolute inset-0 opacity-10" style={{ backgroundImage: 'linear-gradient(to right, #ffffff10 1px, transparent 1px), linear-gradient(to bottom, #ffffff10 1px, transparent 1px)', backgroundSize: '30px 30px' }}></div>
-          
-          {/* Scanning Laser Effect (Only for CodeArena) */}
+
           {isFeatured && (
-            <motion.div 
+            <motion.div
               animate={{ top: ['-10%', '110%'] }}
               transition={{ duration: 4, repeat: Infinity, ease: "linear" }}
               className="absolute inset-x-0 h-[2px] bg-gradient-to-r from-transparent via-purple-400 to-transparent z-0 opacity-50 shadow-[0_0_15px_purple]"
             />
           )}
 
-          {/* Nebula Glows */}
           <div className={`absolute -top-20 -right-20 w-48 h-48 rounded-full blur-[80px] opacity-20 pointer-events-none 
             ${isFeatured ? 'bg-purple-600' : 'bg-blue-600'}`}></div>
 
           <div className="relative z-10 flex flex-col items-center">
-            {/* Icon Wrapper with Orbital Ring */}
-            <div className="relative mb-8">
-                <motion.div 
-                    animate={{ rotate: 360 }} 
-                    transition={{ duration: 15, repeat: Infinity, ease: "linear" }}
-                    className={`absolute -inset-4 border-2 border-dashed rounded-full opacity-30 ${isFeatured ? 'border-purple-400' : 'border-white/20'}`}
-                />
-                <div className={`relative p-6 rounded-full border shadow-2xl transition-transform duration-500 group-hover:scale-110 
+            <div className="relative mb-6 sm:mb-8">
+              <motion.div
+                animate={{ rotate: 360 }}
+                transition={{ duration: 15, repeat: Infinity, ease: "linear" }}
+                className={`absolute -inset-4 border-2 border-dashed rounded-full opacity-30 ${isFeatured ? 'border-purple-400' : 'border-white/20'}`}
+              />
+              <div className={`relative p-4 sm:p-6 rounded-full border shadow-2xl transition-transform duration-500 
                   ${isFeatured ? 'bg-purple-500/10 border-purple-500/30' : 'bg-white/5 border-white/10'}`}>
-                    <Icon size={isFeatured ? 52 : 40} strokeWidth={1} className={isFeatured ? "text-purple-400 drop-shadow-[0_0_8px_#a855f7]" : "text-white"} />
-                </div>
+                <Icon size={isFeatured ? 44 : 32} strokeWidth={1} className={isFeatured ? "text-purple-400 drop-shadow-[0_0_8px_#a855f7]" : "text-white"} />
+              </div>
             </div>
-            
-            <h3 className={`${isFeatured ? 'text-4xl' : 'text-2xl'} font-black text-white uppercase tracking-tighter text-center leading-none`}>
+
+            <h3 className={`${isFeatured ? 'text-3xl sm:text-4xl' : 'text-xl sm:text-2xl'} font-black text-white uppercase tracking-tighter text-center leading-none`}>
               {title}
             </h3>
-            
-            <div className={`h-[2px] w-12 my-5 rounded-full ${isFeatured ? 'bg-purple-500 shadow-[0_0_15px_#a855f7]' : 'bg-gradient-to-r from-transparent via-purple-500/50 to-transparent'}`}></div>
-            
+
+            <div className={`h-[2px] w-12 my-4 sm:my-5 rounded-full ${isFeatured ? 'bg-purple-500 shadow-[0_0_15px_#a855f7]' : 'bg-gradient-to-r from-transparent via-purple-500/50 to-transparent'}`}></div>
+
             <span className={`text-[10px] font-black uppercase tracking-[0.4em] flex items-center gap-2 ${isFeatured ? 'text-purple-300' : 'text-zinc-500'}`}>
-               <Sparkles size={10} /> {isFeatured ? 'Main Mission' : 'Side Quest'}
+              <Sparkles size={10} /> {isFeatured ? 'Main Mission' : 'Side Quest'}
+            </span>
+
+            <span className="mt-4 sm:mt-6 text-[9px] text-zinc-600 uppercase tracking-widest animate-pulse">
+              Tap to reveal
             </span>
           </div>
         </div>
 
-        {/* --- BACK SIDE (Mission Details) --- */}
-        <div className="absolute inset-0 flex flex-col items-center justify-center rounded-[3rem] bg-[#070707] border-2 border-white/20 p-10 text-center [transform:rotateY(180deg)] [backface-visibility:hidden] shadow-2xl overflow-hidden">
-          <span className="text-[10px] font-black text-cyan-400 uppercase tracking-[0.4em] mb-4">
-            System :: Briefing
+        {/* --- BACK SIDE --- */}
+        <div className="absolute inset-0 flex flex-col items-center justify-center rounded-[2rem] sm:rounded-[3rem] bg-[#070707] border-2 border-white/20 p-6 sm:p-10 text-center [transform:rotateY(180deg)] [backface-visibility:hidden] shadow-2xl overflow-hidden">
+          <span className="text-[10px] font-black text-cyan-400 uppercase tracking-[0.4em] mb-3 sm:mb-4">
+            Mission Briefing
           </span>
-          
-          <p className={`${isFeatured ? 'text-lg' : 'text-sm'} leading-relaxed text-zinc-300 font-light`}>
+
+          <div className="space-y-2 mb-4 sm:mb-6 w-full max-w-[260px]">
+            <div className="flex justify-between text-[10px] sm:text-xs border-b border-white/5 pb-1">
+              <span className="text-zinc-500 font-bold uppercase tracking-wider">Platform</span>
+              <span className="text-white font-semibold">{platform}</span>
+            </div>
+            <div className="flex justify-between text-[10px] sm:text-xs border-b border-white/5 pb-1">
+              <span className="text-zinc-500 font-bold uppercase tracking-wider">Date</span>
+              <span className="text-white font-semibold">{date}</span>
+            </div>
+            <div className="flex justify-between text-[10px] sm:text-xs border-b border-white/5 pb-1">
+              <span className="text-zinc-500 font-bold uppercase tracking-wider">Format</span>
+              <span className="text-white font-semibold">{format}</span>
+            </div>
+          </div>
+
+          <p className={`${isFeatured ? 'text-sm sm:text-base' : 'text-xs sm:text-sm'} leading-relaxed text-zinc-400 font-light mb-4 sm:mb-6`}>
             {description}
           </p>
-          
-          <div className={`mt-8 flex items-center gap-2 text-[10px] font-bold text-white uppercase tracking-widest px-8 py-3 rounded-full border transition-all duration-300
-            ${isFeatured ? 'bg-purple-600/20 border-purple-500 hover:bg-white hover:text-black' : 'bg-white/5 border-white/10 hover:bg-white hover:text-black'}`}>
-            Initialize Mission <ChevronRight size={14} />
-          </div>
+
+          <a
+            href={link}
+            data-mission-link="true"
+            target={link.startsWith('http') ? '_blank' : '_self'}
+            rel={link.startsWith('http') ? 'noopener noreferrer' : undefined}
+            className={`flex items-center gap-2 text-[10px] sm:text-xs font-bold text-white uppercase tracking-widest px-6 sm:px-8 py-3 rounded-full border transition-all duration-300 hover:scale-105 active:scale-95
+            ${isFeatured ? 'bg-purple-600/20 border-purple-500 hover:bg-purple-500 hover:text-white' : 'bg-white/5 border-white/10 hover:bg-white hover:text-black'}`}
+          >
+            Register Now <ChevronRight size={14} />
+          </a>
+
+          <button
+            className="mt-3 sm:mt-4 flex items-center gap-1.5 text-[9px] text-zinc-600 uppercase tracking-widest hover:text-zinc-400 transition-colors"
+            onClick={(e) => { e.stopPropagation(); setIsFlipped(false); }}
+          >
+            <RotateCcw size={10} /> Tap to flip back
+          </button>
         </div>
       </motion.div>
-    </motion.a>
+    </motion.div>
   );
 };
 
@@ -95,43 +131,50 @@ const Events = () => {
     {
       title: "Logic Loop",
       icon: Terminal,
-      description: "Sector: Up To Skills. Mission: DSA Logic Gauntlet. Launching: April 5th. Test your algorithmic speed and precision in a high-stakes competitive quiz.",
+      platform: "UpToSkills",
+      date: "5 April",
+      format: "DSA Quiz",
+      description: "Test your algorithmic speed and precision in a high-stakes competitive quiz gauntlet.",
       link: "/codearena",
       delay: 0.1
     },
     {
       title: "CodeArena",
       icon: Zap,
-      description: "Sector: Codeforces. Mission: ICPC-Style CP Battle. Launching April 5th. Solve the complex, optimize the simple, and dominate the live global leaderboard.",
+      platform: "Codeforces",
+      date: "5 April",
+      format: "ICPC-Style CP",
+      description: "Solve the complex, optimize the simple, and dominate the live global leaderboard in a timed coding battle.",
       link: "https://unstop.com/o/1cJ2LFR?utm_medium=Share&utm_source=online_coding_challenge&utm_campaign=Logged_out_userhttps://share.google/JZJwkBcHxZVeJOoh4",
       delay: 0.2
     },
     {
       title: "Vibe Code Arena",
       icon: Layers,
-      description: "Sector: AI-Symmetry. Mission: LLM Prompt Engineering. Active: March 25 – April 4. Leverage the power of the machine to build at the speed of thought.",
+      platform: "HackerEarth",
+      date: "25 Mar – 4 Apr",
+      format: "AI Prompting",
+      description: "Leverage the power of LLMs to build at the speed of thought in this AI-powered coding competition.",
       link: "/codearena",
       delay: 0.3
     }
   ];
 
   return (
-    <section 
-      ref={sectionRef} 
-      className="relative overflow-hidden bg-transparent px-6 py-32"
+    <section
+      ref={sectionRef}
+      className="relative overflow-hidden bg-transparent px-4 sm:px-6 py-16 sm:py-24 md:py-32"
     >
-      {/* Background Ambience (Unchanged as requested) */}
       <div className="absolute top-0 left-1/4 w-96 h-96 bg-purple-600/5 blur-[120px] pointer-events-none"></div>
       <div className="absolute bottom-0 right-1/4 w-96 h-96 bg-cyan-600/5 blur-[120px] pointer-events-none"></div>
 
       <div className="container relative z-10 mx-auto max-w-7xl">
-        
-        {/* Header Section */}
-        <motion.div 
+
+        <motion.div
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          className="relative mb-24 text-center"
+          className="relative mb-12 sm:mb-16 md:mb-24 text-center"
         >
           <div className="flex items-center justify-center gap-4 mb-4">
             <div className="h-[1px] w-12 bg-white/10"></div>
@@ -139,24 +182,26 @@ const Events = () => {
             <div className="h-[1px] w-12 bg-white/10"></div>
           </div>
 
-          <h2 className="text-5xl md:text-8xl font-black tracking-tighter text-white">
+          <h2 className="text-3xl sm:text-5xl md:text-8xl font-black tracking-tighter text-white">
             Our <span className="text-purple-500">Events</span>
           </h2>
-          
-          <p className="mx-auto mt-6 max-w-2xl font-light text-zinc-500 md:text-xl">
+
+          <p className="mx-auto mt-4 sm:mt-6 max-w-2xl font-light text-zinc-500 text-sm sm:text-base md:text-xl">
             Choose your battleground. From pure logic to full-stack endurance.
           </p>
         </motion.div>
 
-        {/* Interactive Cards Area */}
-        <div className="flex flex-col md:flex-row justify-center items-center gap-8 lg:gap-10">
+        <div className="flex flex-col md:flex-row justify-center items-center gap-6 sm:gap-8 lg:gap-10">
           {eventData.map((event, idx) => (
-            <EventCard 
+            <EventCard
               key={idx}
               title={event.title}
               icon={event.icon}
               description={event.description}
               link={event.link}
+              platform={event.platform}
+              date={event.date}
+              format={event.format}
               delay={event.delay}
             />
           ))}

--- a/src/components/sponsors.jsx
+++ b/src/components/sponsors.jsx
@@ -50,9 +50,13 @@ export default function Sponsors() {
 
           <div className="relative mx-auto flex h-[260px] sm:h-[300px] md:h-[340px] lg:h-[420px] w-full max-w-5xl flex-col items-center justify-center overflow-hidden rounded-[2rem] sm:rounded-[3rem] border-2 border-purple-500/40 px-4 sm:px-6 py-8 sm:py-10 shadow-[0_0_45px_rgba(168,85,247,0.25)] md:px-12">
             <div className="pointer-events-none absolute inset-0 opacity-10" style={{ backgroundImage: 'linear-gradient(to right, #ffffff12 1px, transparent 1px), linear-gradient(to bottom, #ffffff12 1px, transparent 1px)', backgroundSize: '34px 34px' }} />
-         
 
-            <div className="relative z-10 mb-5 rounded-full border border-purple-300/35 bg-purple-500/15 p-5 shadow-[0_0_24px_rgba(168,85,247,0.35)] md:p-6">
+
+            <h3 className="relative z-10 text-center text-2xl sm:text-3xl md:text-4xl lg:text-6xl font-black uppercase tracking-tighter text-white mb-5">
+              Powered By
+            </h3>
+
+            <div className="relative z-10 rounded-full border border-purple-300/35 bg-purple-500/15 p-5 shadow-[0_0_24px_rgba(168,85,247,0.35)] md:p-6">
               <img
                 src="/sponsors/unstop.webp"
                 alt="Unstop"
@@ -61,10 +65,6 @@ export default function Sponsors() {
                 loading="lazy"
               />
             </div>
-
-            <h3 className="relative z-10 text-center text-2xl sm:text-3xl md:text-4xl lg:text-6xl font-black uppercase tracking-tighter text-white">
-              Powered By
-            </h3>
 
             <div className="relative z-10 my-4 h-[3px] w-20 rounded-full bg-purple-400 shadow-[0_0_20px_#a855f7]" />
 

--- a/src/components/sponsors.jsx
+++ b/src/components/sponsors.jsx
@@ -48,7 +48,7 @@ export default function Sponsors() {
             className="pointer-events-none absolute left-1/2 top-1/2 h-52 w-[92%] max-w-5xl -translate-x-1/2 -translate-y-1/2 rounded-full bg-purple-500/20 blur-[90px]"
           />
 
-          <div className="relative mx-auto flex h-[340px] w-full max-w-5xl flex-col items-center justify-center overflow-hidden rounded-[3rem] border-2 border-purple-500/40 px-6 py-10 shadow-[0_0_45px_rgba(168,85,247,0.25)] md:h-[420px] md:px-12">
+          <div className="relative mx-auto flex h-[260px] sm:h-[300px] md:h-[340px] lg:h-[420px] w-full max-w-5xl flex-col items-center justify-center overflow-hidden rounded-[2rem] sm:rounded-[3rem] border-2 border-purple-500/40 px-4 sm:px-6 py-8 sm:py-10 shadow-[0_0_45px_rgba(168,85,247,0.25)] md:px-12">
             <div className="pointer-events-none absolute inset-0 opacity-10" style={{ backgroundImage: 'linear-gradient(to right, #ffffff12 1px, transparent 1px), linear-gradient(to bottom, #ffffff12 1px, transparent 1px)', backgroundSize: '34px 34px' }} />
          
 
@@ -62,7 +62,7 @@ export default function Sponsors() {
               />
             </div>
 
-            <h3 className="relative z-10 text-center text-4xl font-black uppercase tracking-tighter text-white md:text-6xl">
+            <h3 className="relative z-10 text-center text-2xl sm:text-3xl md:text-4xl lg:text-6xl font-black uppercase tracking-tighter text-white">
               Powered By
             </h3>
 
@@ -89,7 +89,7 @@ export default function Sponsors() {
               {marqueeLogos.map((logo, idx) => (
                 <div
                   key={idx}
-                  className="flex-shrink-0 flex items-center justify-center p-10 w-80 h-48 rounded-3xl group relative overflow-hidden"
+                  className="flex-shrink-0 flex items-center justify-center p-6 sm:p-8 md:p-10 w-52 h-32 sm:w-64 sm:h-40 md:w-80 md:h-48 rounded-3xl group relative overflow-hidden"
                 >
                   {/* Gradient Background */}
                   <div className="absolute inset-0 bg-gradient-to-br from-purple-500/20 via-transparent to-pink-500/10 rounded-3xl" />

--- a/src/components/ui/Footer.jsx
+++ b/src/components/ui/Footer.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 
 const Footer = () => {
     return (
-        <footer className="bg-black text-white py-6">
-            <div className="container mx-auto flex flex-col md:flex-row justify-between items-center">
-                <div className="mb-4 md:mb-0">
+        <footer className="bg-black text-white py-6 px-4">
+            <div className="container mx-auto flex flex-col md:flex-row justify-between items-center text-center md:text-left gap-4">
+                <div className="mb-2 md:mb-0">
                     <h1 className="text-2xl font-bold">CSEC</h1>
                     <p className="text-sm">© 2024 CSEC. All rights reserved.</p>
                 </div>
-                <div className="flex space-x-4">
+                <div className="flex flex-wrap justify-center gap-4">
                     <a href="https://www.facebook.com/csec.nith" target="_blank" rel="noopener noreferrer" className="text-white hover:text-gray-400">
                         Facebook
                     </a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,6 +1274,11 @@
   resolved "https://registry.npmjs.org/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.3.10.tgz"
   integrity sha512-gh3UAHbUdDUG6fhLc1Csa4IGdtghue6U8oAIXWnUqawp6lwb3gOCRvp25IUnLF5vUHtgfMxuEUYV7YA2WxVutw==
 
+"@oven/bun-windows-x64@1.3.10":
+  version "1.3.10"
+  resolved "https://registry.npmjs.org/@oven/bun-windows-x64/-/bun-windows-x64-1.3.10.tgz"
+  integrity sha512-qaS1In3yfC/Z/IGQriVmF8GWwKuNqiw7feTSJWaQhH5IbL6ENR+4wGNPniZSJFaM/SKUO0e/YCRdoVBvgU4C1g==
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"


### PR DESCRIPTION
refactor(codearena): events carousel + sponsor layout fix

events1.jsx:

Replaced static 3-card flex grid with Embla carousel

Mobile: 1 card visible (85% width) with swipe navigation

Desktop: all 3 cards visible side-by-side (md:basis-1/3)

Added custom space-themed nav arrows + dot indicators

Click-to-flip now triggered by "View Mission" button only (not card body)

Card body click disabled to prevent conflicts with carousel swipe

Each event gets unique accent color (cyan/purple/pink)

Kept structured Mission Briefing back (Platform, Date, Format)

"Register Now" button is sole navigation element

sponsors.jsx:

Moved "Powered By" heading above the Unstop logo

Made sponsor section responsive (height, title, marquee cards)

refactor(codearena): mobile-responsive events carousel + section fixes

events1.jsx:

Replaced static 3-card flex grid with Embla swipeable carousel

Mobile: 1 card visible (85% width) with peek of next, swipe to navigate

Desktop: all 3 cards visible side-by-side (md:basis-1/3)

Custom space-themed nav arrows (purple glow) + dot indicators

Click-to-flip only via "View Mission" button (prevents swipe conflicts)

Each event has unique accent color (cyan/purple/pink)

Structured Mission Briefing on back (Platform, Date, Format)